### PR TITLE
Document Flyway ClickHouse plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Official documentation on the JSON format that the request submodule parses can 
 The server is implemented in Kotlin using Ktor and stores metrics in ClickHouse. ECG voltages include an additional `sample_index` column to avoid deduplication when timestamps repeat and use `DateTime64` to preserve sub-second precision.
 Database schema migrations are managed with Flyway and run automatically when the server starts. Migration scripts live under `src/main/resources/db/migration` and create all eleven tables (`metrics`, `workouts`, `state_of_mind`, `workout_routes`, `workout_heart_rate_data`, `workout_heart_rate_recovery`, `workout_step_count_log`, `workout_walking_running_distance`, `workout_active_energy`, `ecg`, and `ecg_voltage`).
 
+## Flyway and ClickHouse
+Flyway requires a ClickHouse extension in order to recognize `jdbc:clickhouse` URLs. The Gradle build includes this dependency:
+
+```kotlin
+implementation("org.flywaydb:flyway-database-clickhouse:10.18.0")
+```
+
+If this dependency is missing you'll encounter `No database found to handle jdbc:clickhouse` during startup.
+
 ## Configuration
 You can configure the application using environment variables:
 - `CLICKHOUSE_DSN`: The DSN (Data Source Name) for connecting to ClickHouse

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
     implementation("com.clickhouse:clickhouse-jdbc:0.8.6")
     implementation("org.flywaydb:flyway-core:10.14.0")
+    implementation("org.flywaydb:flyway-database-clickhouse:10.18.0")
     implementation("org.slf4j:slf4j-simple:2.0.12")
     testImplementation(kotlin("test"))
 }


### PR DESCRIPTION
## Summary
- explain that Flyway needs an extra ClickHouse database plugin
- add the plugin dependency to `build.gradle.kts`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68407c2a465c832591b74a8b86e0c027