### PR TITLE
Add save statistics output

### DIFF
--- a/src/main/kotlin/healthImportServer/ImportHandler.kt
+++ b/src/main/kotlin/healthImportServer/ImportHandler.kt
@@ -33,10 +33,24 @@ class ImportHandler(private val metricStore: ClickHouseMetricStore) {
 
             println("Starting upload to metric store \"${metricStore.name}\".")
 
-            if (localMetrics.isNotEmpty()) metricStore.store(localMetrics)
-            if (localEcg.isNotEmpty()) metricStore.storeEcg(localEcg)
-            if (localWorkouts.isNotEmpty()) metricStore.storeWorkouts(localWorkouts)
-            if (localStateOfMind.isNotEmpty()) metricStore.storeStateOfMind(localStateOfMind)
+            if (localMetrics.isNotEmpty()) {
+                metricStore.store(localMetrics)
+                val samples = localMetrics.sumOf { it.data.size }
+                println("Saved ${localMetrics.size} metrics with $samples samples")
+            }
+            if (localEcg.isNotEmpty()) {
+                metricStore.storeEcg(localEcg)
+                val voltages = localEcg.sumOf { it.voltageMeasurements.size }
+                println("Saved ${localEcg.size} ECG entries with $voltages voltage measurements")
+            }
+            if (localWorkouts.isNotEmpty()) {
+                metricStore.storeWorkouts(localWorkouts)
+                println("Saved ${localWorkouts.size} workouts")
+            }
+            if (localStateOfMind.isNotEmpty()) {
+                metricStore.storeStateOfMind(localStateOfMind)
+                println("Saved ${localStateOfMind.size} state of mind entries")
+            }
 
             metricStore.optimizeTables()
             println("Finished upload to metric store \"${metricStore.name}\" and optimized tables.")


### PR DESCRIPTION
## Summary
- print how many metrics, ECG recordings, workouts and state of mind entries are saved during the upload process

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6840891f6a3c8325b7dc720b39592a71