### PR TITLE
Fix timestamp parsing and ECG voltage dates

### DIFF
--- a/src/main/kotlin/healthImportServer/request/Export.kt
+++ b/src/main/kotlin/healthImportServer/request/Export.kt
@@ -71,7 +71,7 @@ data class ECG(
 
 @Serializable
 data class ECGVoltage(
-    val date: String? = null,
+    val date: Double? = null,
     val voltage: Double? = null,
     val units: String? = null
 )


### PR DESCRIPTION
## Summary
- handle ISO 8601 timestamps in `parseTs`
- accept numeric ECG voltage timestamps and convert to Instant

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68408eb02f208325b09aaa74ee2376e4