### PR TITLE
Add detailed logging of saved rows

### DIFF
--- a/src/main/kotlin/healthImportServer/ClickHouseMetricStore.kt
+++ b/src/main/kotlin/healthImportServer/ClickHouseMetricStore.kt
@@ -233,6 +233,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (r in w.route) {
                     val ts = r.timestamp ?: start
+                    println("Batching workout route for $id: $r")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, r.latitude ?: 0.0)
@@ -268,6 +269,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (h in w.heartRateData) {
                     val ts = h.date ?: start
+                    println("Batching workout heart rate data for $id: $h")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, h.qty ?: 0.0)
@@ -300,6 +302,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (h in w.heartRateRecovery) {
                     val ts = h.date ?: start
+                    println("Batching workout heart rate recovery for $id: $h")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, h.qty ?: 0.0)
@@ -332,6 +335,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (s in w.stepCount) {
                     val ts = s.date ?: start
+                    println("Batching step count log for $id: $s")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, s.qty ?: 0.0)
@@ -361,6 +365,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (s in w.walkingAndRunningDistance) {
                     val ts = s.date ?: start
+                    println("Batching walking/running distance for $id: $s")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, s.qty ?: 0.0)
@@ -390,6 +395,7 @@ class ClickHouseMetricStore(private val config: ClickHouseConfig) : AutoCloseabl
                 val start = w.start ?: continue
                 for (s in w.activeEnergy) {
                     val ts = s.date ?: start
+                    println("Batching workout active energy for $id: $s")
                     stmt.setString(1, id)
                     stmt.setTimestamp(2, parseTs(ts))
                     stmt.setDouble(3, s.qty ?: 0.0)

--- a/src/main/kotlin/healthImportServer/ImportHandler.kt
+++ b/src/main/kotlin/healthImportServer/ImportHandler.kt
@@ -34,20 +34,37 @@ class ImportHandler(private val metricStore: ClickHouseMetricStore) {
             println("Starting upload to metric store \"${metricStore.name}\".")
 
             if (localMetrics.isNotEmpty()) {
+                println("Metrics to save:")
+                for (metric in localMetrics) {
+                    for (sample in metric.data) {
+                        println("\t${metric.name} (${metric.units}): $sample")
+                    }
+                }
                 metricStore.store(localMetrics)
                 val samples = localMetrics.sumOf { it.data.size }
                 println("Saved ${localMetrics.size} metrics with $samples samples")
             }
             if (localEcg.isNotEmpty()) {
+                println("ECG to save:")
+                for (e in localEcg) {
+                    println("\t$e")
+                    for (v in e.voltageMeasurements) {
+                        println("\t\t$v")
+                    }
+                }
                 metricStore.storeEcg(localEcg)
                 val voltages = localEcg.sumOf { it.voltageMeasurements.size }
                 println("Saved ${localEcg.size} ECG entries with $voltages voltage measurements")
             }
             if (localWorkouts.isNotEmpty()) {
+                println("Workouts to save:")
+                for (w in localWorkouts) println("\t$w")
                 metricStore.storeWorkouts(localWorkouts)
                 println("Saved ${localWorkouts.size} workouts")
             }
             if (localStateOfMind.isNotEmpty()) {
+                println("State of mind to save:")
+                for (s in localStateOfMind) println("\t$s")
                 metricStore.storeStateOfMind(localStateOfMind)
                 println("Saved ${localStateOfMind.size} state of mind entries")
             }

--- a/src/main/kotlin/healthImportServer/tools/RequestParse.kt
+++ b/src/main/kotlin/healthImportServer/tools/RequestParse.kt
@@ -1,24 +1,44 @@
 package me.centralhardware.healthImportServer.tools
 
 import me.centralhardware.healthImportServer.request.RequestParser
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import java.nio.file.Files
 import java.nio.file.Paths
 
 /**
  * Parses `request.json` and prints the parsed data as JSON to stdout.
  */
-fun main(args: Array<String>) {
-    val logJson = args.firstOrNull() != "--no-log"
+fun main() {
     val body = Files.readString(Paths.get("request.json"))
     val export = RequestParser.parse(body)
-    if (logJson) {
-        val json = Json { prettyPrint = true }
-        println("Metrics:")
-        println(json.encodeToString(export.metrics))
-        println("\nWorkouts:")
-        println(json.encodeToString(export.workouts))
+    println("Metrics:")
+    for (metric in export.metrics) {
+        for (sample in metric.data) {
+            println("\t${metric.name} (${metric.units}): $sample")
+        }
+    }
+
+    println("\nWorkouts:")
+    for (workout in export.workouts) {
+        println("\t$workout")
+        for (route in workout.route) println("\t\tRoute: $route")
+        for (hr in workout.heartRateData) println("\t\tHeartRateData: $hr")
+        for (hr in workout.heartRateRecovery) println("\t\tHeartRateRecovery: $hr")
+        for (sc in workout.stepCount) println("\t\tStepCount: $sc")
+        for (dist in workout.walkingAndRunningDistance) println("\t\tWalkingRunningDistance: $dist")
+        for (ae in workout.activeEnergy) println("\t\tActiveEnergy: $ae")
+    }
+
+    if (export.stateOfMind.isNotEmpty()) {
+        println("\nState of mind:")
+        for (s in export.stateOfMind) println("\t$s")
+    }
+
+    if (export.ecg.isNotEmpty()) {
+        println("\nECG:")
+        for (e in export.ecg) {
+            println("\t$e")
+            for (v in e.voltageMeasurements) println("\t\t$v")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- print every inserted row for workout-related tables
- log all entries prior to storing in `ImportHandler`
- update request parser utility to dump rows instead of JSON

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684093e7b8ac8325a77cb14a3e1c8284